### PR TITLE
Added HardSub Functionality To AnimeKai's Server

### DIFF
--- a/src/providers/anime/animekai/animekai.ts
+++ b/src/providers/anime/animekai/animekai.ts
@@ -499,9 +499,11 @@ export class AnimeKai {
 
       const $ = cheerio.load(serverHtml);
       const servers: AnimeKaiServer[] = [];
-
-      const serverItems = $(`.server-items.lang-group[data-id="${subOrDub}"] .server`);
-
+      
+      // Map internal types to site data-ids: hardsub -> "sub", softsub -> "softsub", dub -> "dub"
+      const targetId = subOrDub === "hardsub" ? "sub" : subOrDub;
+      const serverItems = $(`.server-items.lang-group[data-id="${targetId}"] .server`);
+      
       await Promise.all(
         serverItems.toArray().map(async (server) => {
           const lid = $(server).attr("data-lid");
@@ -558,10 +560,12 @@ export class AnimeKai {
       const $ = cheerio.load(serverHtml);
       const results: any[] = [];
 
-      const langGroups =
-        subOrDub === "dub"
-          ? [".server-items.lang-group[data-id='dub']"]
-          : [".server-items.lang-group[data-id='softsub']", ".lang-group[data-id='softsub']"];
+      // Define target data-id based on input
+      const targetId = subOrDub === "hardsub" ? "sub" : subOrDub;
+      const langGroups = [`.server-items.lang-group[data-id='${targetId}']`];
+
+      // Fallback for softsub if needed
+      if (subOrDub === "softsub") langGroups.push(".lang-group[data-id='softsub']");
 
       const seen = new Set<string>();
       for (const group of langGroups) {

--- a/src/providers/anime/animekai/animekai.ts
+++ b/src/providers/anime/animekai/animekai.ts
@@ -570,6 +570,7 @@ export class AnimeKai {
       const seen = new Set<string>();
       for (const group of langGroups) {
         const isDub = group.includes("[data-id='dub']");
+        const isHard = group.includes("[data-id='sub']");
         const serverItems = $(`${group} .server`);
 
         for (const item of serverItems.toArray()) {
@@ -586,7 +587,7 @@ export class AnimeKai {
           const videoSources = await MegaUp.extract(decoded.url);
 
           results.push({
-            name: `MegaUp ${$(item).text().trim()}${isDub ? " (Dub)" : ""}`,
+            name: `MegaUp ${$(item).text().trim()}${isDub ? " (Dub)" : isHard ? " (HardSub)" : ""}`,
             url: decoded.url,
             intro: decoded.skip.intro,
             outro: decoded.skip.outro,

--- a/src/providers/anime/animekai/route.ts
+++ b/src/providers/anime/animekai/route.ts
@@ -109,9 +109,14 @@ export const animekaiRoutes = new Elysia({ prefix: "/animekai" })
       set.status = 400;
       return { message: "episodeId is required" };
     }
+    
+    // Determine type: check 'type' param first, then fallback to 'dub' param, default to 'hardsub'
+    const typeParam = qs?.type as string;
     const dubParam = qs?.dub;
-    const subOrDub: "softsub" | "dub" = dubParam === "true" || dubParam === "1" ? "dub" : "softsub";
-
+    const subOrDub: "softsub" | "dub" | "hardsub" = 
+      (typeParam === "softsub" || typeParam === "dub" || typeParam === "hardsub") 
+        ? typeParam 
+        : (dubParam === "true" || dubParam === "1") ? "dub" : "hardsub";
     // episodeId format: "animeSlug$ep=N$token=TOKEN"
     const animeSlug = episodeId.split("$")[0] ?? episodeId;
     const results = await AnimeKai.streams(animeSlug, episodeId, subOrDub);
@@ -124,7 +129,12 @@ export const animekaiRoutes = new Elysia({ prefix: "/animekai" })
       set.status = 400;
       return { message: "episodeId is required" };
     }
+    const typeParam = qs?.type as string;
     const dubParam = qs?.dub;
-    const subOrDub: "softsub" | "dub" = dubParam === "true" || dubParam === "1" ? "dub" : "softsub";
+
+    const subOrDub: "softsub" | "dub" | "hardsub" = 
+      (typeParam === "softsub" || typeParam === "dub" || typeParam === "hardsub") 
+        ? typeParam 
+        : (dubParam === "true" || dubParam === "1") ? "dub" : "hardsub";
     return { servers: await AnimeKai.fetchEpisodeServers(episodeId, subOrDub) };
   });

--- a/src/providers/anime/animekai/types.ts
+++ b/src/providers/anime/animekai/types.ts
@@ -60,7 +60,7 @@ export const animekaiInfoSchema = z.object({
   anilistId: z.string().optional(),
   hasSub: z.boolean().optional(),
   hasDub: z.boolean().optional(),
-  subOrDub: z.enum(["sub", "dub", "both"]).optional(),
+  subOrDub: z.enum(["sub", "dub", "both", "hardsub"]).optional(),
   genres: z.array(z.string()).optional(),
   recommendations: z.array(animekaiRelatedItemSchema).optional(),
   relations: z.array(animekaiRelatedItemSchema).optional(),

--- a/src/providers/anime/route.ts
+++ b/src/providers/anime/route.ts
@@ -43,7 +43,7 @@ export const animeRoutes = new Elysia({ prefix: "/anime" })
           "GET /anime/animekai/genre/:genre           → Search by genre",
           "GET /anime/animekai/info?id=               → Full anime info + episodes",
           "GET /anime/animekai/watch/:episodeId        → Stream sources (query: type=hardsub|softsub|dub)",
-          "GET /anime/animekai/servers/:episodeId     → Episode servers (query: dub)",
+          "GET /anime/animekai/servers/:episodeId     → Episode servers (query: type=hardsub|softsub|dub)",
         ],
         toonstream: [
           "GET /anime/toonstream/home                           → Home page (featured + recent)",

--- a/src/providers/anime/route.ts
+++ b/src/providers/anime/route.ts
@@ -42,7 +42,7 @@ export const animeRoutes = new Elysia({ prefix: "/anime" })
           "GET /anime/animekai/genres                 → List all genres",
           "GET /anime/animekai/genre/:genre           → Search by genre",
           "GET /anime/animekai/info?id=               → Full anime info + episodes",
-          "GET /anime/animekai/watch/:episodeId       → Stream sources (query: dub)",
+          "GET /anime/animekai/watch/:episodeId        → Stream sources (query: type=hardsub|softsub|dub)",
           "GET /anime/animekai/servers/:episodeId     → Episode servers (query: dub)",
         ],
         toonstream: [


### PR DESCRIPTION
I've updated the API so you can now specify your preferred version using ?type=hardsub, softsub, or dub. By default, it now serves the HardSub version and clearly labels each server name in the response.

example( watch endpoint) -
https://test.com/anime/animekai/watch/hells-paradise-season-2-5ev9$ep=1$token=Ltf8uPzxuxun1HRfxImJ?type=hardsub   {or softsub or dub}

servers endpoint) - 
https://test.com/anime/animekai/servers/hells-paradise-season-2-5ev9$ep=1$token=Ltf8uPzxuxun1HRfxImJ?type=hardsub